### PR TITLE
Added WP-CLI to PATH deps

### DIFF
--- a/content/guide/getting-started/setting-up-flynt.md
+++ b/content/guide/getting-started/setting-up-flynt.md
@@ -21,6 +21,7 @@ These tools must be available in your system's PATH environment.
 | ------------------------------------------------------- | ------- |
 | [Node](https://nodejs.org/)                             | >= 6.0  |
 | [Composer](https://getcomposer.org/)                    | >= 1.2  |
+| [WP-CLI](http://wp-cli.org/)                    | >= 0.22.0  |
 | [Yarn](https://yarnpkg.com/)*                           | >= 0.21 |
 | [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer)** | >= 2.5  |
 


### PR DESCRIPTION
I tried installing with an older version of WP-CLI (sorry not sure what version it was, might be able to update once i get back home) and was receiving an error about apply_filters not being defined in wp-includes/load.php.

Updated WP-CLI to the latest as of last night and resolved the error.